### PR TITLE
 [RFC] add two types of landscapemaker; do not merge; close #7

### DIFF
--- a/src/NeutralLandscapes.jl
+++ b/src/NeutralLandscapes.jl
@@ -4,7 +4,8 @@ import NaNMath
 using Random: rand!
 
 abstract type NeutralLandscapeMaker end
-export NeutralLandscapeMaker
+abstract type ContinuousNeutralLandscapeMaker <: NeutralLandscapeMaker end
+abstract type DiscreteNeutralLandscapeMaker <: NeutralLandscapeMaker end
 
 include("landscape.jl")
 export rand, rand!

--- a/src/algorithms/edgegradient.jl
+++ b/src/algorithms/edgegradient.jl
@@ -7,7 +7,7 @@ expressed as a floating point value, which will be in *[0,360]*. The inner
 constructor takes the mod of the value passed and 360, so that a value that is
 out of the correct interval will be corrected.
 """
-struct EdgeGradient <: NeutralLandscapeMaker
+struct EdgeGradient <: ContinuousNeutralLandscapeMaker
     direction::Float64
     EdgeGradient(x::T) where {T <: Real} = new(mod(x, 360.0))
 end

--- a/src/algorithms/nogradient.jl
+++ b/src/algorithms/nogradient.jl
@@ -3,7 +3,7 @@
 
 This type is used to generate a random landscape with no gradients
 """
-struct NoGradient <: NeutralLandscapeMaker
+struct NoGradient <: ContinuousNeutralLandscapeMaker
 end
 
 _landscape!(mat, ::NoGradient) where {IT <: Integer} = rand!(mat)

--- a/src/algorithms/planargradient.jl
+++ b/src/algorithms/planargradient.jl
@@ -7,7 +7,7 @@ expressed as a floating point value, which will be in *[0,360]*. The inner
 constructor takes the mod of the value passed and 360, so that a value that is
 out of the correct interval will be corrected.
 """
-struct PlanarGradient <: NeutralLandscapeMaker
+struct PlanarGradient <: ContinuousNeutralLandscapeMaker
     direction::Float64
     PlanarGradient(x::T) where {T <: Real} = new(mod(x, 360.0))
 end

--- a/src/algorithms/wavesurface.jl
+++ b/src/algorithms/wavesurface.jl
@@ -4,7 +4,7 @@
 Creates a sinusoidal landscape with a `direction` and a number of `periods`. If
 neither are specified, there will be a single period of random direction.
 """
-struct WaveSurface <: NeutralLandscapeMaker
+struct WaveSurface <: ContinuousNeutralLandscapeMaker
     direction::Float64
     periods::Int64
     function WaveSurface(x::T, y::K) where {T <: Real, K <: Integer}

--- a/src/landscape.jl
+++ b/src/landscape.jl
@@ -41,8 +41,13 @@ Fill the matrix `mat` with a landscape created following the model defined by
 `alg`. The `mask` argument accepts a matrix of boolean values, and is passed to
 `mask!` if it is not `nothing`. 
 """
-function rand!(mat::AbstractArray{<:AbstractFloat,2} where N, alg::T; mask=nothing) where {T <: NeutralLandscapeMaker}
+function rand!(mat::AbstractArray{<:AbstractFloat,2} where N, alg::T; mask=nothing) where {T <: ContinuousNeutralLandscapeMaker}
     _landscape!(mat, alg)
     isnothing(mask) || mask!(mat, mask)
     _rescale!(mat)
+end
+
+function rand!(mat::AbstractArray{<:AbstractFloat,2} where N, alg::T; mask=nothing) where {T <: DiscreteNeutralLandscapeMaker}
+    _landscape!(mat, alg)
+    isnothing(mask) || mask!(mat, mask)
 end


### PR DESCRIPTION
Because discrete landscapes shouldn't be rescaled - there are possibly other reasons too