### PR TITLE
:art: explicitly import sample

### DIFF
--- a/src/NeutralLandscapes.jl
+++ b/src/NeutralLandscapes.jl
@@ -1,7 +1,7 @@
 module NeutralLandscapes
 
 import NaNMath
-import StatsBase
+using StatsBase: sample
 using Random: rand!
 using Statistics: quantile
 using Distributions: Normal

--- a/src/algorithms/nnelement.jl
+++ b/src/algorithms/nnelement.jl
@@ -19,7 +19,7 @@ NearestNeighborElement() = NearestNeighborElement(3, 1)
 
 function _landscape!(mat, alg::NearestNeighborElement)
     fill!(mat, 0.0)
-    clusters = StatsBase.sample(eachindex(mat), alg.n; replace=false)
+    clusters = sample(eachindex(mat), alg.n; replace=false)
     for (i,n) in enumerate(clusters)
         mat[n] = i
     end  


### PR DESCRIPTION
Not sure what people feel here, but just for consistency I've imported `sample` explicitly rather than importing StatsBase. I personally like that you can easily see what you import the various packages for.