### PR TITLE
correct constructor in gallery for MidpointDisplacement 

### DIFF
--- a/docs/src/gallery.md
+++ b/docs/src/gallery.md
@@ -69,5 +69,5 @@ demolandscape(DiamondSquare())
 
 ## Midpoint Displacement
 ```@example gallery
-demolandscape(MPD())
+demolandscape(MidpointDisplacement())
 ```


### PR DESCRIPTION
changes the constructor used in `docs/src/gallery.md` for midpoint-displacement from the old name of the type (`MPD()`) to the current name `MidpointDisplacement()`,