### PR TITLE
Tp/abstractfloats

### DIFF
--- a/src/algorithms/diamondsquare.jl
+++ b/src/algorithms/diamondsquare.jl
@@ -216,7 +216,7 @@ Random value are drawn from a Gaussian distribution using `Distribution.Normal`
 The standard deviation of this Gaussian, σ, is set to (1/2)^(round*H), which
 will move from 1.0 to 0 as `round` increases.
 """
-_displace(H::AbstractFloat, round::Int) rand(Normal(0, 0.5^(round*H)))
+_displace(H::AbstractFloat, round::Int) = rand(Normal(0, 0.5^(round*H)))
 
 
 """
@@ -249,7 +249,8 @@ Returns the y-coordinate from a lattice coordinate `pt`.
 """
     _edgeMidpointCoordinates(corners::AbstractVector{Tuple{Int,Int}})
 
-    Returns an array of midpoints for a square defined by `corners` for the `DiamondSquare` algorithm.
+Returns an array of midpoints for a square defined by `corners` for the
+`DiamondSquare` algorithm.
 """
 function _edgeMidpointCoordinates(corners::AbstractVector{Tuple{Int,Int}})
     # bottom left, bottom right, top left, top right
@@ -265,10 +266,11 @@ function _edgeMidpointCoordinates(corners::AbstractVector{Tuple{Int,Int}})
 end
 
 """
-     _isPowerOfTwo(x::IT) where {IT <: Integer}
+    _isPowerOfTwo(x::IT) where {IT <: Integer}
 
-     Determines if `x`, an integer, can be expressed as `2^n`, where `n` is also an integer.
+Determines if `x`, an integer, can be expressed as `2^n`, where `n` is also an
+integer.
 """
-function _isPowerOfTwo(x::IT) where {IT <: Integer}
+function _isPowerOfTwo(x::Int)
     return x & (x-1) == 0
 end

--- a/src/algorithms/distancegradient.jl
+++ b/src/algorithms/distancegradient.jl
@@ -5,7 +5,7 @@ The `sources` field is the *linear* indices of the matrix, from which the
 distance must be calculated.
 """
 struct DistanceGradient <: NeutralLandscapeMaker
-    sources::Vector{Integer}
+    sources::Vector{Int}
 end
 
 DistanceGradient() = DistanceGradient([1])
@@ -13,7 +13,7 @@ DistanceGradient() = DistanceGradient([1])
 function _landscape!(mat, alg::DistanceGradient)
     @assert maximum(alg.sources) <= length(mat)
     @assert minimum(alg.sources) > 0
-    coordinates = Matrix{Float64}(undef, (2, prod(size(mat))))
+    coordinates = Matrix{AbstractFloat}(undef, (2, prod(size(mat))))
     for (i, p) in enumerate(Iterators.product(axes(mat)...))
         coordinates[1:2, i] .= p
     end

--- a/src/algorithms/edgegradient.jl
+++ b/src/algorithms/edgegradient.jl
@@ -8,13 +8,13 @@ constructor takes the mod of the value passed and 360, so that a value that is
 out of the correct interval will be corrected.
 """
 struct EdgeGradient <: NeutralLandscapeMaker
-    direction::Float64
+    direction::Real
     EdgeGradient(x::T) where {T <: Real} = new(mod(x, 360.0))
 end
 
 EdgeGradient() = EdgeGradient(360rand())
 
-function _landscape!(mat, alg::EdgeGradient) where {IT <: Integer}
+function _landscape!(mat, alg::EdgeGradient)
     _landscape!(mat, PlanarGradient(alg.direction))
     mat .= -2.0abs.(0.5 .- mat) .+ 1.0
 end

--- a/src/algorithms/nnelement.jl
+++ b/src/algorithms/nnelement.jl
@@ -5,8 +5,8 @@ Assigns a value to each patch using a k-NN algorithmm with `n` initial clusters
 and `k` neighbors. The default is to use three cluster and a single neighbor.
 """
 struct NearestNeighborElement <: NeutralLandscapeMaker
-    n::Int64
-    k::Int64
+    n::Int
+    k::Int
     function NearestNeighborElement(n::Int64, k::Int64)
         @assert n > 0
         @assert k > 0
@@ -15,6 +15,12 @@ struct NearestNeighborElement <: NeutralLandscapeMaker
     end
 end
 
+"""
+    NearestNeighborElement()
+
+When given no arguments, partitions the landscape using the closest of three
+neighbors.
+"""
 NearestNeighborElement() = NearestNeighborElement(3, 1)
 
 function _landscape!(mat, alg::NearestNeighborElement)
@@ -23,7 +29,7 @@ function _landscape!(mat, alg::NearestNeighborElement)
     for (i,n) in enumerate(clusters)
         mat[n] = i
     end  
-    coordinates = Matrix{Float64}(undef, (2, prod(size(mat))))
+    coordinates = Matrix{AbstractFloat}(undef, (2, prod(size(mat))))
     for (i, p) in enumerate(Iterators.product(axes(mat)...))
         coordinates[1:2, i] .= p
     end

--- a/src/algorithms/planargradient.jl
+++ b/src/algorithms/planargradient.jl
@@ -8,7 +8,7 @@ constructor takes the mod of the value passed and 360, so that a value that is
 out of the correct interval will be corrected.
 """
 struct PlanarGradient <: NeutralLandscapeMaker
-    direction::Float64
+    direction::AbstractFloat
     PlanarGradient(x::T) where {T <: Real} = new(mod(x, 360.0))
 end
 
@@ -19,7 +19,7 @@ Creates a `PlanarGradient` with a random direction.
 """
 PlanarGradient() = PlanarGradient(360rand())
 
-function _landscape!(mat, alg::PlanarGradient) where {IT <: Integer}
+function _landscape!(mat, alg::PlanarGradient)
     eastness = sin(deg2rad(alg.direction))
     southness = -1cos(deg2rad(alg.direction))
     rows, cols = axes(mat)

--- a/src/algorithms/rectangularcluster.jl
+++ b/src/algorithms/rectangularcluster.jl
@@ -6,14 +6,20 @@ rectangle/patch is between `minimum` and `maximum` (the two can be equal for a
 fixed size rectangle).
 """
 struct RectangularCluster <: NeutralLandscapeMaker
-    minimum::Integer
-    maximum::Integer
-    function RectangularCluster(x::T, y::T) where {T <: Integer}
+    minimum::Int
+    maximum::Int
+    function RectangularCluster(x::Int, y::Int)
         @assert 0 < x <= y
         new(x, y)
     end
 end
 
+"""
+    RectangularCluster()
+
+When given no arguments, the rectangular clusters will have dimensions between 2
+and 4.
+"""
 RectangularCluster() = RectangularCluster(2,4)
 
 function _landscape!(mat, alg::RectangularCluster)

--- a/src/algorithms/wavesurface.jl
+++ b/src/algorithms/wavesurface.jl
@@ -5,14 +5,20 @@ Creates a sinusoidal landscape with a `direction` and a number of `periods`. If
 neither are specified, there will be a single period of random direction.
 """
 struct WaveSurface <: NeutralLandscapeMaker
-    direction::Float64
-    periods::Int64
-    function WaveSurface(x::T, y::K) where {T <: Real, K <: Integer}
+    direction::AbstractFloat
+    periods::Int
+    function WaveSurface(x::AbstractFloat, y::Int)
         @assert y >= 1
         new(mod(x, 360.0), y)
     end
 end
 
+"""
+    WaveSurface()
+
+When given no argument, `WaveSurface` returns a single period at a random
+orientation.
+"""
 WaveSurface() = WaveSurface(360rand(), 1)
 
 function _landscape!(mat, alg::WaveSurface)

--- a/src/landscape.jl
+++ b/src/landscape.jl
@@ -16,7 +16,7 @@ end
 Modifies `array` so that the positions at which `maskarray` is `false` are
 replaced by `NaN`.
 """
-function mask!(array::AbstractArray{<:Float64}, maskarray::AbstractArray{<:Bool}) 
+function mask!(array::AbstractArray{<:AbstractFloat}, maskarray::AbstractArray{<:Bool}) 
     (size(array) == size(maskarray)) || throw(DimensionMismatch("The dimensions of array, $(size(array)), and maskarray, $(size(maskarray)), must match. "))
     array[.!maskarray] .= NaN
     array
@@ -29,8 +29,8 @@ Creates a landscape of size `dims` (a tuple of two integers) following the model
 defined by `alg`. The `mask` argument accepts a matrix of boolean values, and is
 passed to `mask!` if it is not `nothing`. 
 """
-function Base.rand(alg::T, dims::Tuple{Int64,Int64}; mask=nothing) where {T <: NeutralLandscapeMaker}
-    ret = Matrix{Float64}(undef, dims...)
+function Base.rand(alg::T, dims::Tuple{Int,Int}; mask=nothing) where {T <: NeutralLandscapeMaker}
+    ret = Matrix{AbstractFloat}(undef, dims...)
     rand!(ret, alg; mask=mask)
 end
 Base.rand(alg::T, dims::Integer...; mask=nothing) where {T <: NeutralLandscapeMaker} = rand(alg, dims; mask = mask)
@@ -42,7 +42,7 @@ Fill the matrix `mat` with a landscape created following the model defined by
 `alg`. The `mask` argument accepts a matrix of boolean values, and is passed to
 `mask!` if it is not `nothing`. 
 """
-function rand!(mat::AbstractArray{<:AbstractFloat,2} where N, alg::T; mask=nothing) where {T <: NeutralLandscapeMaker}
+function rand!(mat::AbstractArray{<:AbstractFloat,2}, alg::T; mask=nothing) where {T <: NeutralLandscapeMaker}
     _landscape!(mat, alg)
     isnothing(mask) || mask!(mat, mask)
     _rescale!(mat)


### PR DESCRIPTION
Mostly (the rest is docstring) changes to make sure we don't restrict the types to Int64/Float64 (as remote teaching revealed that 32-bits laptops are still very much a thing). 