### PR TITLE
Add NearestNeighborCluster algorithm

### DIFF
--- a/src/NeutralLandscapes.jl
+++ b/src/NeutralLandscapes.jl
@@ -43,6 +43,9 @@ export RectangularCluster
 include(joinpath("algorithms", "nnelement.jl"))
 export NearestNeighborElement
 
+include(joinpath("algorithms", "nncluster.jl"))
+export NearestNeighborCluster
+
 include(joinpath("algorithms", "perlinnoise.jl"))
 export PerlinNoise
 

--- a/src/algorithms/nncluster.jl
+++ b/src/algorithms/nncluster.jl
@@ -1,8 +1,9 @@
 """
-    NearestNeighborCluster
+    NearestNeighborCluster(p, n)
 
 Create a random cluster nearest-neighbour neutral landscape model with 
-values ranging 0-1.
+values ranging 0-1. `p` sets the density of original clusters, and `n`
+sets the neighborhood for clustering (see `?label` for neighborhood options)
 """
 struct NearestNeighborCluster <: NeutralLandscapeMaker
     p::Float64

--- a/src/algorithms/nncluster.jl
+++ b/src/algorithms/nncluster.jl
@@ -16,7 +16,8 @@ struct NearestNeighborCluster <: NeutralLandscapeMaker
 end
 
 function _landscape!(mat, alg::NearestNeighborCluster)
-    classify!(_landscape!(mat, NoGradient()), [alg. p, 1 - alg.p])
+    _landscape!(mat, NoGradient())
+    classify!(mat, [alg. p, 1 - alg.p])
     replace!(mat, 2.0 => NaN)
     clusters, nClusters = label(mat, alg.n)
     coordinates = _coordinatematrix(clusters)

--- a/src/algorithms/nncluster.jl
+++ b/src/algorithms/nncluster.jl
@@ -1,0 +1,24 @@
+"""
+    NearestNeighborElement
+
+Create a random cluster nearest-neighbour neutral landscape model with 
+values ranging 0-1.
+"""
+struct NearestNeighborCluster{T<:AbstractFloat} <: NeutralLandscapeMaker
+    p::T
+    n::Symbol
+    function NearestNeighborCluster(p::T = 0.5, n::Symbol = :rook)
+        @assert p > 0
+        @assert n ∈ (:rook, :queen, :diagonal)
+        new(p,n)
+    end
+end
+
+NearestNeighborCluster(p::T = 0.5, n::Symbol = :rook) where T <: AbstractFloat = 
+    NearestNeighborCluster{T}(p, n)
+
+function _landscape!(mat, alg::NearestNeighborElement)
+    # I ignore the masking here - all the other algos apply it after only
+    classify!(rand!(mat), [1 - p, p])
+    clusters, nClusters = label(mat)
+    clusters .= rand(nClusters)[clusters]

--- a/src/algorithms/nncluster.jl
+++ b/src/algorithms/nncluster.jl
@@ -17,7 +17,7 @@ end
 
 function _landscape!(mat, alg::NearestNeighborCluster)
     _landscape!(mat, NoGradient())
-    classify!(mat, [alg. p, 1 - alg.p])
+    classify!(mat, [alg.p, 1 - alg.p])
     replace!(mat, 2.0 => NaN)
     clusters, nClusters = label(mat, alg.n)
     coordinates = _coordinatematrix(clusters)

--- a/src/algorithms/nncluster.jl
+++ b/src/algorithms/nncluster.jl
@@ -17,7 +17,7 @@ end
 function _landscape!(mat, alg::NearestNeighborCluster)
     classify!(_landscape!(mat, NoGradient()), [1 - alg.p, alg.p])
     replace!(mat, 2.0 => NaN)
-    clusters, nClusters = label(mat)
+    clusters, nClusters = label(mat, alg.n)
     coordinates = _coordinatematrix(clusters)
     sources = findall(!isnan, vec(clusters))
     tree = KDTree(coordinates[:,sources])

--- a/src/algorithms/nncluster.jl
+++ b/src/algorithms/nncluster.jl
@@ -16,7 +16,7 @@ struct NearestNeighborCluster <: NeutralLandscapeMaker
 end
 
 function _landscape!(mat, alg::NearestNeighborCluster)
-    classify!(_landscape!(mat, NoGradient()), [1 - alg.p, alg.p])
+    classify!(_landscape!(mat, NoGradient()), [alg. p, 1 - alg.p])
     replace!(mat, 2.0 => NaN)
     clusters, nClusters = label(mat, alg.n)
     coordinates = _coordinatematrix(clusters)

--- a/src/algorithms/nnelement.jl
+++ b/src/algorithms/nnelement.jl
@@ -17,16 +17,21 @@ end
 
 NearestNeighborElement() = NearestNeighborElement(3, 1)
 
+function _coordinatematrix(mat)
+    coordinates = Matrix{Float64}(undef, (2, prod(size(mat))))
+    for (i, p) in enumerate(Iterators.product(axes(mat)...))
+        coordinates[1:2, i] .= p
+    end
+    coordinates
+end
+
 function _landscape!(mat, alg::NearestNeighborElement)
     fill!(mat, 0.0)
     clusters = sample(eachindex(mat), alg.n; replace=false)
     for (i,n) in enumerate(clusters)
         mat[n] = i
     end  
-    coordinates = Matrix{Float64}(undef, (2, prod(size(mat))))
-    for (i, p) in enumerate(Iterators.product(axes(mat)...))
-        coordinates[1:2, i] .= p
-    end
+    coordinates = _coordinatematrix(mat)
     tree = KDTree(coordinates[:,clusters])
     if alg.k  == 1
         mat[:] .= nn(tree, coordinates)[1]


### PR DESCRIPTION
This is the final landscape algorithm. Maybe some testing to work out whether it really gives the same results would be in order.
One difference in behaviour is that the original code applies the `mask` first here. That means that for masks with many NaNs, this code here might end with numbers of cluster that for reasons of random sampling are more spread out around the target value of `p`. Ameliorating this would require making a specific `rand!` method for this particular NeutralLandscapeMaker, so it loses some consistency. Thoughts?

```julia
plot(
   heatmap(rand(NearestNeighborCluster(0.4), 50, 50)), 
   heatmap(rand(NearestNeighborCluster(0.5), 50, 50)), 
   heatmap(rand(NearestNeighborCluster(0.6), 50, 50)), 
   layout = (1,3), size = (1200, 400), colorbar = false, title = ["p = 0.4" "p = 0.5" "p = 0.6"]
)
```
![nncluster](https://user-images.githubusercontent.com/8429802/109000616-3ae91500-76a4-11eb-98c3-19285b55909e.png)
