### PR TITLE
[wip][rfc] New readme from Fig1; fix #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,16 @@ Fig1s = rotr90(Fig1l)
 # Transposed NLM
 Fig1t = Fig1o'
 
+class = cgrad(:Set3_4, 4, categorical = true)
+c2, c3, c4 = class[1:2], class[1:3], class[1:4]
+
 gr(color = :fire, ticks = false, framestyle = :box, colorbar = false)
 plot(
-    heatmap(Fig1a), heatmap(Fig1b), heatmap(Fig1c), heatmap(Fig1d), heatmap(Fig1e),
-    heatmap(Fig1f), heatmap(Fig1g), heatmap(Fig1h), heatmap(Fig1i), heatmap(Fig1j), 
-    heatmap(Fig1k), heatmap(Fig1l), heatmap(Fig1m), heatmap(Fig1n), heatmap(Fig1o),
-    heatmap(Fig1p), heatmap(Fig1q), heatmap(Fig1r), heatmap(Fig1s), heatmap(Fig1t),
-    layout = (4,5), size = (1600, 1300)
+    heatmap(Fig1a),         heatmap(Fig1b),         heatmap(Fig1c),         heatmap(Fig1d, c = c2), heatmap(Fig1e),
+    heatmap(Fig1f),         heatmap(Fig1g),         heatmap(Fig1h),         heatmap(Fig1i),         heatmap(Fig1j), 
+    heatmap(Fig1k),         heatmap(Fig1l, c = c4), heatmap(Fig1m, c = c2), heatmap(Fig1n, c = c2), heatmap(Fig1o, c = c3),
+    heatmap(Fig1p, c = c4), heatmap(Fig1q),         heatmap(Fig1r, c = c4), heatmap(Fig1s, c = c4), heatmap(Fig1t, c = c3),
+    layout = (4,5), size = (1600, 1270)
 )
 ```
-![Fig1](https://user-images.githubusercontent.com/8429802/109274687-1613af80-7814-11eb-8a58-1fb0ee43c7e2.png)
+![Fig1](https://user-images.githubusercontent.com/8429802/109293089-998ccb00-782b-11eb-864f-b25522e7b746.png)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Fig1q = rand(PlanarGradient(90), siz, mask = Fig1n .== 2) #TODO mask as keyword 
 # Hierarchical NLM
 Fig1r = ifelse.(Fig1o .== 2, Fig1m .+ 2, Fig1o)
 # Rotated NLM
-Fig1s = rot(Fig1l) #TODO
+Fig1s = rotr90(Fig1l)
 # Transposed NLM
 Fig1t = Fig1o'
 
@@ -58,7 +58,7 @@ plot(
     heatmap(Fig1a), heatmap(Fig1b), heatmap(Fig1c), heatmap(Fig1d), heatmap(Fig1e),
     heatmap(Fig1f), heatmap(Fig1g), heatmap(Fig1h), heatmap(Fig1i), heatmap(Fig1j), 
     heatmap(Fig1k), heatmap(Fig1l), heatmap(Fig1m), heatmap(Fig1n), heatmap(Fig1o),
-    heatmap(Fig1p), heatmap(Fig1q), heatmap(Fig1r), heatmap(Fig1t), heatmap(Fig1t),
+    heatmap(Fig1p), heatmap(Fig1q), heatmap(Fig1r), heatmap(Fig1s), heatmap(Fig1t),
     layout = (4,5), size = (1600, 1300)
 )
 ```

--- a/README.md
+++ b/README.md
@@ -2,32 +2,64 @@
 
 **Python source:** https://github.com/tretherington/nlmpy
 
+This is a direct port of the NLMpy neutral landscape generation package to julia.
+This code reproduces Fig 1 from the paper introducing the package: 
+
+Etherington, T.R., Holland, E.P. & O’Sullivan, D. (2015) NLMpy: a python software package for the creation of neutral landscape models within a general numerical framework. _Methods in Ecology and Evolution_, __6__, 164–168.
+
 ```julia
-using NeutralLandscapes
+using NeutralLandscapes, Plots
+siz = 50, 50
 
-julia> grad = PlanarGradient(60.0)
-PlanarGradient(60.0)
+# Random NLM
+Fig1a = rand(NoGradient(), siz)
+# Planar gradient NLM
+Fig1b = rand(PlanarGradient(), siz)
+# Edge gradient NLM
+Fig1c = rand(EdgeGradient(), siz)
+# Mask example
+Fig1d = falses(siz)
+Fig1d[10:25, 10:25] .= true
+# Distance gradient NLM
+Fig1e = rand(DistanceGradient(findall(vec(Fig1d))), siz)
+# Midpoint displacement NLM
+Fig1f = rand(MidpointDisplacement(0.75), siz)
+# Random rectangular cluster NLM
+Fig1g = rand(RectangularCluster(4, 8), siz)
+# Random element nearest-neighbor NLM
+Fig1h = rand(NearestNeighborElement(200), siz)
+# Random cluster nearest-neighbor NLM
+Fig1i = rand(NearestNeighborCluster(0.4), siz)
+# Blended NLM
+Fig1j = blend([Fig1f, Fig1c])
+# Patch blended NLM
+Fig1k = blend(Fig1h, Fig1e, 1.5)
+# Classifiend random cluster nearest-neighbor NLM
+Fig1l = classify(Fig1i, ones(4))
+# Percolation NLM
+Fig1m = classify(Fig1a, [1-0.5, 0.5])
+# Binary random rectangular cluster NLM
+Fig1n = classify(Fig1g, [1-0.75, 0.75])
+# Classified midpoint displacement NLM
+Fig1o = classify(Fig1f, ones(3))
+# Classified midpoind displacement NLM, with limited classification
+Fig1p = classify(Fig1f, ones(3), Fig1d)
+# Masked planar gradient NLM
+Fig1q = rand(PlanarGradient(90), siz, mask = Fig1n .== 2) #TODO mask as keyword + should mask be matrix or vec or both? (Fig1e)
+# Hierarchical NLM
+Fig1r = ifelse.(Fig1o .== 2, Fig1m .+ 2, Fig1o)
+# Rotated NLM
+Fig1s = rot(Fig1l) #TODO
+# Transposed NLM
+Fig1t = Fig1o'
 
-julia> mask = rand(4, 6) .> 0.2
-4×6 BitMatrix:
- 1  1  1  1  1  1
- 1  1  0  1  1  0
- 1  1  1  0  1  0
- 1  1  0  1  1  1
-
-julia> rand(grad, (4, 6), mask = mask)
-4×6 Matrix{Float64}:
- 0.257284   0.405827    0.554371    0.702914  0.851457    1.0
- 0.171523   0.320066  NaN           0.617152  0.765695  NaN
- 0.0857614  0.234305    0.382848  NaN         0.679934  NaN
- 0.0        0.148543  NaN           0.445629  0.594173    0.742716
-
- using Plots
+gr(color = :fire, ticks = false, framestyle = :box, colorbar = false)
 plot(
-    heatmap(rand(grad, (100, 100)), title = "Planar"),
-    heatmap(rand(grad, (100, 100), mask = rand(100, 100) .> 0.2), title = "Planar + mask"),
-    heatmap(rand(EdgeGradient(30), (100, 100)), title = "Edge"),
-    layout = (1,3), size = (900, 300), colorbar = false
+    heatmap(Fig1a), heatmap(Fig1b), heatmap(Fig1c), heatmap(Fig1d), heatmap(Fig1e),
+    heatmap(Fig1f), heatmap(Fig1g), heatmap(Fig1h), heatmap(Fig1i), heatmap(Fig1j), 
+    heatmap(Fig1k), heatmap(Fig1l), heatmap(Fig1m), heatmap(Fig1n), heatmap(Fig1o),
+    heatmap(Fig1p), heatmap(Fig1q), heatmap(Fig1r), heatmap(Fig1t), heatmap(Fig1t),
+    layout = (4,5), size = (1600, 1300)
 )
 ```
-![three landscapes](https://user-images.githubusercontent.com/8429802/107582714-3596bf80-6bfa-11eb-93ad-4202be6425e6.png)
+![Fig1](https://user-images.githubusercontent.com/8429802/109274687-1613af80-7814-11eb-8a58-1fb0ee43c7e2.png)

--- a/src/algorithms/nnelement.jl
+++ b/src/algorithms/nnelement.jl
@@ -7,7 +7,7 @@ and `k` neighbors. The default is to use three cluster and a single neighbor.
 struct NearestNeighborElement <: NeutralLandscapeMaker
     n::Int64
     k::Int64
-    function NearestNeighborElement(n::Int64, k::Int64)
+    function NearestNeighborElement(n::Int64, k::Int64 = 1)
         @assert n > 0
         @assert k > 0
         @assert k <= n

--- a/src/classify.jl
+++ b/src/classify.jl
@@ -7,9 +7,11 @@ function classify!(array, weights, mask = nothing)
     quantiles = zeros(length(weights))
     cumsum!(quantiles, weights)
     quantiles ./= quantiles[end]
-    boundaryvalues = isnothing(mask) ?
-    quantile(filter(isfinite, array), quantiles) :
-    quantile(array[mask .& isfinite.(array)], quantiles)
+    boundaryvalues = if isnothing(mask)
+        quantile(filter(isfinite, array), quantiles)
+    else
+        quantile(array[mask .& isfinite.(array)], quantiles)
+    end
     for i in eachindex(array)
         array[i] = isnan(array[i]) ? NaN : searchsortedfirst(boundaryvalues, array[i])
     end


### PR DESCRIPTION
This adds a readme that recreates Fig1 of the NLMpy paper as suggested in #42. 

This is their Fig1:
![billede](https://user-images.githubusercontent.com/8429802/109274353-af8e9180-7813-11eb-9167-7ef4ed63a1d9.png)

This is the one of this PR:
![Fig1](https://user-images.githubusercontent.com/8429802/109274687-1613af80-7814-11eb-8a58-1fb0ee43c7e2.png)

The code here ports this file https://besjournals.onlinelibrary.wiley.com/action/downloadSupplement?doi=10.1111%2F2041-210X.12308&file=mee312308-sup-0002-dataS2.py
to our julia format. As you can see there are some discrepancies that we could revisit to make our syntax more intuitive.

I also don't really know about Fig1s, and of course I just need to update the colors on the classified ones.