### PR TITLE
Fix compilation issue on LTS due to changes in NearestNeighbors (NN) API

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.9'
+          - 'lts'
+          - '1'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
         experimental: [false]
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -36,7 +36,7 @@ jobs:
         env:
           GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: ./lcov.info
           flags: unittests

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NeutralLandscapes"
 uuid = "71847384-8354-4223-ac08-659a5128069f"
 authors = ["Timothée Poisot <timothee.poisot@umontreal.ca>", "Michael Krabbe Borregaard <mkborregaard@sund.ku.dk>", "Michael David Catchen <michael.catchen@mail.mcgill.ca>", "Rafael Schouten <rafaelschouten@gmail.com>", "Virgile Baudrot <virgile.baudrot@posteo.net>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/NeutralLandscapes.jl
+++ b/src/NeutralLandscapes.jl
@@ -7,7 +7,11 @@ using Statistics: quantile, mean
 using Distributions: Normal, LogNormal, MvNormal, Categorical, pdf
 using NearestNeighbors: KDTree, knn, nn, knn_point!, SVector
 
-const always_false = isdefined(NearestNeighbors, :always_false) ? NearestNeighbors.always_false : Returns(false)
+import NearestNeighbors
+always_false = Returns(false)
+if isdefined(NearestNeighbors, :always_false)
+    global always_false = NearestNeighbors.always_false
+end
 
 using DataStructures: IntDisjointSets, union!, find_root, push!
 using Base: @kwdef

--- a/src/NeutralLandscapes.jl
+++ b/src/NeutralLandscapes.jl
@@ -5,7 +5,10 @@ using StatsBase: sample, ZScoreTransform, fit, transform
 using Random: rand!
 using Statistics: quantile, mean
 using Distributions: Normal, LogNormal, MvNormal, Categorical, pdf
-using NearestNeighbors: KDTree, knn, nn, always_false, knn_point!, SVector
+using NearestNeighbors: KDTree, knn, nn, knn_point!, SVector
+
+const always_false = isdefined(NearestNeighbors, :always_false) ? NearestNeighbors.always_false : Returns(false)
+
 using DataStructures: IntDisjointSets, union!, find_root, push!
 using Base: @kwdef
 using HaltonSequences: haltonvalue


### PR DESCRIPTION
**What the pull request does**   
A change in `NL` (`always_false` as an export was replaced  by `Returns(false)` broke precompilation.

Fixes #76 

This has been fixed by creating a global variable `always_false = Returns(false)`. If `NN` exports `always_false`, this one is used instead. The later is important as previous versions of `NN` may not handle `Returns(false)`. This results in _no_ change to the package code.

**Type of change**   
- [x] :bug: Bug fix (non-breaking change which fixes an issue)

**Checklist**
- [x] The changes are tested
- [x] The changes **do not** modify the behavior of the previously existing functions
- [x] The `Project.toml` field `version` has been updated